### PR TITLE
Allow hard-coded breakpoint() or trepan.api.debug disable

### DIFF
--- a/trepan/api.py
+++ b/trepan/api.py
@@ -177,12 +177,32 @@ def debug(
     if post_mortem:
         debugger_on_post_mortem()
         pass
+
+    # Add breakpoint to list of breakpoints if it is not there.
+    # And if it is there determine whether it has been disabled.
+    bpmgr = core.bpmgr
+    code = frame.f_code
+    filename = code.co_filename
+    line_number = frame.f_lineno
+
+    bp = bpmgr.find_breakpoint(filename, line_number)
+    if bp is None:
+        bp = core.bpmgr.add_breakpoint(
+            filename=filename,
+            line_number=line_number,
+            is_code_offset=False,
+            condition=None,
+            func_or_code=code)
+    elif not bp.enabled:
+        core.step_ignore = -1
+        return
+
     if 0 == step_ignore:
         frame = sys._getframe(1 + level)
         core.stop_reason = "at a debug() call"
         old_trace_hook_suspend = core.trace_hook_suspend
         core.trace_hook_suspend = True
-        core.processor.event_processor(frame, "line", None)
+        core.processor.event_processor(frame, "debug", None)
         core.trace_hook_suspend = old_trace_hook_suspend
     else:
         core.step_ignore = step_ignore - 1

--- a/trepan/lib/breakpoint.py
+++ b/trepan/lib/breakpoint.py
@@ -416,7 +416,7 @@ class BreakpointManager:
             self.delete_breakpoint(bp)
         return bpnums
 
-    def find_bp(self, filename: str, line_number: int, frame):
+    def find_bp(self, filename: str, line_number: int, frame) -> tuple:
         """Determine which breakpoint for this file:line is to be acted upon.
 
         Called only if we know there is a bpt at this
@@ -465,6 +465,22 @@ class BreakpointManager:
                 pass
             pass
         return (None, None)
+
+    def find_breakpoint(self, filename: str, line_number: int) -> Optional[Breakpoint]:
+        """Check for a breakpoint() or trepan.api.debug call
+
+        Called only if we know there is a breakpoint at this
+        location.  Returns breakpoint that was triggered and a flag
+        that indicates if it is ok to delete a temporary breakpoint.
+
+        """
+        possibles = self.bplist[filename, line_number]
+        if len(possibles) > 0:
+            # Count every hit when bp is enabled
+            b = possibles[0]
+            b.hits += 1
+            return b
+        return None
 
     def last(self):
         return len(self.bpbynumber) - 1

--- a/trepan/processor/cmdproc.py
+++ b/trepan/processor/cmdproc.py
@@ -172,6 +172,7 @@ class CommandProcessor(Processor):
         self.event2short = dict(EVENT2SHORT)
         self.event2short["signal"] = "?!"
         self.event2short["brkpt"] = "xx"
+        self.event2short["debug"] = "db"  # debug() call
 
         self.optional_modules = ("ipython", "bpy")
         self.cmd_instances = self._populate_commands()


### PR DESCRIPTION
Trace hard-coded breakpoint() the same way we'd do for a breakpoint command. Allow disabling that breakpoint the same as we can for a command breakpoint.